### PR TITLE
Update json.php for php8 support

### DIFF
--- a/json.php
+++ b/json.php
@@ -44,9 +44,7 @@ switch ($_SERVER['REQUEST_METHOD']) {
 	//	break;
 	case 'POST':
 		foreach ($_POST as $key=>$val) {
-			if (get_magic_quotes_gpc()) {
-				$val = stripslashes($val);
-			}
+			$val = stripslashes($val);
 			$dec = @json_decode($val, true);
 			if ($dec === NULL) {
 				$err = response('Error decoding the argument '.quot($key).' => '.var_dump_inl($val), 400);


### PR DESCRIPTION
get_magic_quotes_gpc() is not supported in php8, so stripslashes are always executed